### PR TITLE
Updating delay based on comments from last pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Add plugin configuration to your `pom.xml`:
 			<goals>
 				<goal>deploy</goal>
 			</goals>
+                        <configuration>
+                                <waitForDeploymentFinished>true</waitForDeploymentFinished>
+                                <waitForDeploymentTimeout>10<waitForDeploymentTimeout>
+                        </configuration>
 		</execution>
 		<execution>
 			<id>apptasks</id>
@@ -49,7 +53,6 @@ Add plugin configuration to your `pom.xml`:
 			</goals>
 			<configuration>
 				<propertyPrefix>mesos-</propertyPrefix>
-				<delay>5</delay>
 			</configuration>
 		</execution>
 		<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>cc.roden</groupId>
 			<artifactId>marathon-client</artifactId>
-			<version>0.4.7</version>
+			<version>0.4.8-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>cc.roden</groupId>
 			<artifactId>marathon-client</artifactId>
-			<version>0.4.8-SNAPSHOT</version>
+			<version>0.4.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>

--- a/src/main/java/com/holidaycheck/marathon/maven/DeployMojo.java
+++ b/src/main/java/com/holidaycheck/marathon/maven/DeployMojo.java
@@ -22,10 +22,21 @@
 package com.holidaycheck.marathon.maven;
 
 import static com.holidaycheck.marathon.maven.Utils.readApp;
+
 import mesosphere.marathon.client.Marathon;
 import mesosphere.marathon.client.MarathonClient;
 import mesosphere.marathon.client.model.v2.App;
-import mesosphere.marathon.client.utils.MarathonException;
+import mesosphere.marathon.client.model.v2.Deployment;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -44,7 +55,13 @@ public class DeployMojo extends AbstractMarathonMojo {
      */
     @Parameter(property = "marathonHost", required = true)
     private String marathonHost;
-    
+
+    @Parameter(property = "waitForDeploymentFinished", required = false)
+    private boolean waitForDeploymentFinished = false;
+
+    @Parameter(property = "waitForDeploymentTimeout", required = false)
+    private Long waitForDeploymentTimeout = 10L;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         final Marathon marathon = MarathonClient.getInstance(marathonHost);
@@ -56,7 +73,11 @@ public class DeployMojo extends AbstractMarathonMojo {
             updateApp(marathon, app);
         } else {
             getLog().info(app.getId() + " does not exist yet - will be created");
-            createApp(marathon, app);
+            final App createdApp = createApp(marathon, app);
+
+            if (waitForDeploymentFinished) {
+                waitForApp(marathon, createdApp);
+            }
         }
     }
 
@@ -69,12 +90,67 @@ public class DeployMojo extends AbstractMarathonMojo {
         }
     }
 
-    private void createApp(Marathon marathon, App app) throws MojoExecutionException {
+    private App createApp(Marathon marathon, App app) throws MojoExecutionException {
         try {
-            marathon.createApp(app);
+            return marathon.createApp(app);
         } catch (Exception createAppException) {
             throw new MojoExecutionException("Failed to push Marathon config file to "
                     + marathonHost, createAppException);
+        }
+    }
+
+    /**
+     * Get the marathon deployments in a loop until we find our deployment is
+     * completed or we have a timeout.
+     */
+    private void waitForApp(Marathon marathon, App app) {
+        //transform our app deployments into a collection of ids
+        final Collection<String> appDeploymentIds = Collections2.transform(
+                app.getDeployments(), new DeploymentIdExtractor());
+
+        //capture our start time
+        final long start = new Date().getTime();
+
+        //loop until we time out.  if we are successful then the loop will exit
+        while (new Date().getTime() - start < waitForDeploymentTimeout * 1000) {
+            //TODO(bsneade) - we should probably add a filter on the affected apps here
+            final Collection<String> matchingDeploymentIds = 
+                    Collections2.transform(Collections2.filter(
+                            marathon.getDeployments(), new SpecificAppPredicate(app.getId())),
+                            new DeploymentIdExtractor());
+
+            //match our app's deployment ids against the list of active ones
+            //  if none of our ids are in active deployment, then we have started up.
+            if (Collections.disjoint(appDeploymentIds, matchingDeploymentIds)) {
+                getLog().info("All deployments are started: " + appDeploymentIds);
+                return;
+            }
+            
+            getLog().debug("Deployment still found for at least one deployment id");
+        }
+
+        //we normally exited the while loop, so we have a timeout.
+        getLog().warn("Timeout waiting for deployment: " + appDeploymentIds);
+    }
+
+    private static class DeploymentIdExtractor implements Function<Deployment, String> {
+        @Override
+        public String apply(@Nonnull final Deployment input) {
+            return input.getId();
+        }
+    }
+
+    private static class SpecificAppPredicate implements Predicate<Deployment> {
+        
+        final String appId;
+
+        public SpecificAppPredicate(final String appId) {
+            this.appId = appId;
+        }
+
+        @Override
+        public boolean apply(@Nonnull final Deployment input) {
+            return input.getAffectedApps().contains(this.appId);
         }
     }
 

--- a/src/main/java/com/holidaycheck/marathon/maven/DeployMojo.java
+++ b/src/main/java/com/holidaycheck/marathon/maven/DeployMojo.java
@@ -113,15 +113,15 @@ public class DeployMojo extends AbstractMarathonMojo {
 
         //loop until we time out.  if we are successful then the loop will exit
         while (new Date().getTime() - start < waitForDeploymentTimeout * 1000) {
-            //TODO(bsneade) - we should probably add a filter on the affected apps here
-            final Collection<String> matchingDeploymentIds = 
+            //get the list of active deployment ids filtered by our app id 
+            final Collection<String> activeDeploymentIds = 
                     Collections2.transform(Collections2.filter(
                             marathon.getDeployments(), new SpecificAppPredicate(app.getId())),
                             new DeploymentIdExtractor());
 
             //match our app's deployment ids against the list of active ones
             //  if none of our ids are in active deployment, then we have started up.
-            if (Collections.disjoint(appDeploymentIds, matchingDeploymentIds)) {
+            if (Collections.disjoint(appDeploymentIds, activeDeploymentIds)) {
                 getLog().info("All deployments are started: " + appDeploymentIds);
                 return;
             }


### PR DESCRIPTION
Discussion on last pull request https://github.com/holidaycheck/marathon-maven-plugin/pull/1

The ProcessConfigMojo no longer has the delay on it.  The DeployMojo now has two new params (waitForDeploymentFinished, waitForDeploymentTimeout) to have the deploy task wait until the container deployment is complete.  

NOTE: wait until the 0.4.8 version of marathon-client land in maven central before merging http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22cc.roden%22
0.4.8 is a result of this pull request: https://github.com/willroden/marathon-client/pull/4
