### PR TITLE
update marathon-client to enable use of labels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>cc.roden</groupId>
 			<artifactId>marathon-client</artifactId>
-			<version>0.4.7</version>
+			<version>0.4.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
This updates marathon client to latest release (v0.4.9).
This version includes the latest fields conversion such as 'labels' and 'deployments' within an app declaration in marathon.json

In version v0.4.7 of marathon client they are filtered out.
