### PR TITLE
add maven resource filtering for marathon config file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
 			<version>3.2.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-filtering</artifactId>
+			<version>3.1.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.plugin-testing</groupId>
 			<artifactId>maven-plugin-testing-harness</artifactId>
 			<version>3.2.0</version>

--- a/src/main/java/com/holidaycheck/marathon/maven/ProcessConfigMojo.java
+++ b/src/main/java/com/holidaycheck/marathon/maven/ProcessConfigMojo.java
@@ -24,13 +24,24 @@ package com.holidaycheck.marathon.maven;
 import static com.holidaycheck.marathon.maven.Utils.readApp;
 import static com.holidaycheck.marathon.maven.Utils.writeApp;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import mesosphere.marathon.client.model.v2.App;
 
+import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.MavenFilteringException;
+import org.apache.maven.shared.filtering.MavenResourcesExecution;
+import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 
 /**
  * Used to process Marathon config file.
@@ -51,24 +62,51 @@ public class ProcessConfigMojo extends AbstractMarathonMojo {
      */
     @Parameter(property = "image", required = true)
     private String image;
-    
+
     /**
      * ID to use for the Marathon config.
      */
     @Parameter(property = "id", required = false)
     private String id;
 
+    @Parameter(property = "encoding", defaultValue = "${project.build.sourceEncoding}")
+    protected String encoding;
+
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
+    private MavenProject project;
+
+    @Component(role = MavenResourcesFiltering.class, hint = "default")
+    protected MavenResourcesFiltering resourcesFiltering;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         getLog().info("processing Marathon config file from " + sourceMarathonConfigFile
                 + " to " + finalMarathonConfigFile);
-        App app = readApp(sourceMarathonConfigFile);
+        App app = readApp(filterSourceFile(sourceMarathonConfigFile));
         if (id != null) {
             app.setId(id);
         }
         app.getContainer().getDocker().setImage(image);
         writeApp(app, finalMarathonConfigFile);
+    }
+
+    private String filterSourceFile(final String inputFile) {
+        final File targetDir = new File(System.getProperty("java.io.tmpdir"));
+        final File sourceFile = new File(inputFile);
+        final Resource resource = new Resource();
+        resource.setDirectory(sourceFile.getParent());
+        resource.getIncludes().add("**" + File.separator + sourceFile.getName());
+        resource.setFiltering(true);
+        final List<String> filters = Collections.emptyList();
+        final List<String> nonFilteredFileExtensions = Collections.emptyList();
+        try {
+            resourcesFiltering.filterResources(new MavenResourcesExecution(Arrays.asList(resource),
+                    targetDir, project, encoding, filters, nonFilteredFileExtensions, session));
+            return targetDir + File.separator + sourceFile.getName();
+        } catch (final NullPointerException | MavenFilteringException e) {
+            getLog().warn("resource filtering of Marathon config file failed", e);
+            return inputFile;
+        }
     }
 
 }


### PR DESCRIPTION
Add maven resource filtering so that marathon config file is easier to customise.

Just like https://github.com/marccarre/properties-files-maven-plugin/issues/7 maven filtering fails in tests. Verified manually.
